### PR TITLE
Update second.rs

### DIFF
--- a/2020/day3/src/bin/second.rs
+++ b/2020/day3/src/bin/second.rs
@@ -13,7 +13,7 @@ fn parse_map(input: &str) -> Result<TreeMap> {
     }).collect()
 }
 
-fn find_trees(input: &str, right: usize, down: usize) -> Result<usize> {
+fn find_trees(input: &str, right: usize, down: usize) -> usize {
     let tree_map = parse_map(input)?;
     Ok(tree_map.into_iter().enumerate().filter_map(|(y, row)| {
         if y % down == 0 {
@@ -29,7 +29,7 @@ fn find_trees(input: &str, right: usize, down: usize) -> Result<usize> {
 fn main() -> Result<()> {
     let input = fs::read_to_string("input.txt")?;
     let angles = vec![(1, 1), (3, 1), (5, 1), (7, 1), (1, 2)];
-    let result: usize = angles.into_iter().map(|(right, down)| find_trees(&input, right, down).unwrap()).product();
+    let result: usize = angles.into_iter().map(|(right, down)| find_trees(&input, right, down)).product();
     println!("{:?}", result);
     Ok(())
 }


### PR DESCRIPTION
Probably no need to return `Result` only to immediately `unwrap()` it.

Another note, when `if row[x] {` is replaced to `if row[x] == '#' {` you can save initial `map` over each line of the input file. Although it could be a matter of taste and (I just realized) you ARE saving on memory usage - `bool` is 1 byte, when `char` is 4 bytes due to Unicode. So, theoretically 1 byte the comparison is faster as well. Eh... just a thought. :) I didn't bother converting the input to bool in my solution.